### PR TITLE
Use hop like a true vim motion

### DIFF
--- a/lua/user/hop.lua
+++ b/lua/user/hop.lua
@@ -6,8 +6,8 @@ M.config = function()
     return
   end
   hop.setup()
-  vim.api.nvim_set_keymap("n", "s", ":HopChar2<cr>", { silent = true })
-  vim.api.nvim_set_keymap("n", "S", ":HopWord<cr>", { silent = true })
+  vim.api.nvim_set_keymap("", "s", ":HopChar2<cr>", { silent = true })
+  vim.api.nvim_set_keymap("", "S", ":HopWord<cr>", { silent = true })
 end
 
 return M


### PR DESCRIPTION
I know this is your personal config, but you are missing out on so much fun that I feel compelled to make this PR. 😆 
By binding the hop commands in operator pending mode you can use 's' / 'S' as a motion with 'y', 'd' and 'c' just like any other vim motion. And also in visual mode to select till target using hop.