### PR TITLE
Fix lualine deprecation warning

### DIFF
--- a/lua/user/lualine.lua
+++ b/lua/user/lualine.lua
@@ -352,7 +352,7 @@ M.config = function()
   if ok then
     ins_left {
       "diagnostics",
-      sources = { "nvim" },
+      sources = { "nvim_diagnostic" },
       symbols = { error = " ", warn = " ", info = " ", hint = " " },
       sections = { "error", "warn" },
       -- sections = {'error', 'warn', 'info', 'hint'},


### PR DESCRIPTION
replacing "nvim" with "nvim_diagnostic" as source as suggested in this commit: https://github.com/nvim-lualine/lualine.nvim/commit/4231b63196a0dcc94e62e914d2b768ef31b5beb7